### PR TITLE
feat: Allow max concurrency for parallel map with option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ nal.map(
 
 ## API
 
-### `map(values, iterator[, extensions][, callback])`
+### `map(values, iterator[, options][, callback])`
 
 Takes an object or array of `values` and an `iterator` function to execute with each value.
-Optionally, takes an `extensions` object and a `callback` function that is called upon completion of the iterations.
+Optionally, takes an `options` object and a `callback` function that is called upon completion of the iterations.
 
 All iterations run in parallel.
 
@@ -105,11 +105,17 @@ The `iterator` function is called once with each `value`, `key` and a function (
 
 If `done` is passed an error as the first argument, the iteration will fail and the sequence will be ended; however, any iterations in progress will still complete. If `done` is passed a `result` value as the second argument, it will be added to the final results array or object.
 
-#### `extensions`
+#### `options`
 
-The `extensions` object is used for specifying functions that give insight into the lifecycle of each iteration. The possible extension points are `create`, `before`, `after` and `error`. If an extension point is not specified, it defaults to a no-op function.
+The `options` object is primarily used for specifying functions that give insight into the lifecycle of each iteration. The possible extension points are `create`, `before`, `after` and `error`. If an extension point is not specified, it defaults to a no-op function.
 
-##### `extensions.create(value, key)`
+The `options` object for `map` also allows specifying `concurrency` in which to run your iterations. By default, your iterations will run at maximum concurrency.
+
+##### `options.concurrency`
+
+Limits the amount of iterations allowed to run at a given time.
+
+##### `options.create(value, key)`
 
 Called at the very beginning of each iteration with the `value` being iterated and the `key` from the array or object. If `create` returns a value (`storage`), it is passed to the `before`, `after` and `error` extension points.
 
@@ -117,15 +123,15 @@ If a value is not returned, an empty object is used as `storage` for each other 
 
 This is useful for tracking information across an iteration.
 
-##### `extensions.before(storage)`
+##### `options.before(storage)`
 
 Called immediately before each iteration with the `storage` value returned from the `create` extension point.
 
-##### `extensions.after(result, storage)`
+##### `options.after(result, storage)`
 
 Called immediately after each iteration with the `result` of the iteration and the `storage` value returned from the `create` extension point.
 
-##### `extensions.error(error, storage)`
+##### `options.error(error, storage)`
 
 Called immediately after a failed iteration with the `error` of the iteration and the `storage` value returned from the `create` extension point.
 
@@ -137,10 +143,10 @@ If all iterations completed successfully, the `error` argument will be empty and
 
 If an iteration errored, the `error` argument will be passed from that iteration and the `results` will be whatever partial results had completed successfully before the error occurred.
 
-### `mapSeries(values, iterator[, extensions][, callback])`
+### `mapSeries(values, iterator[, options][, callback])`
 
 Takes an object or array of `values` and an `iterator` function to execute with each value.
-Optionally, takes an `extensions` object and a `callback` function that is called upon completion of the iterations.
+Optionally, takes an `options` object and a `callback` function that is called upon completion of the iterations.
 
 All iterations run in serial.
 
@@ -160,11 +166,11 @@ The `iterator` function is called once with each `value`, `key` and a function (
 
 If `done` is passed an error as the first argument, the iteration will fail and the sequence will be ended without executing any more iterations. If `done` is passed a `result` value as the second argument, it will be added to the final results array or object.
 
-#### `extensions`
+#### `options`
 
-The `extensions` object is used for specifying functions that give insight into the lifecycle of each iteration. The possible extension points are `create`, `before`, `after` and `error`. If an extension point is not specified, it defaults to a no-op function.
+The `options` object is primarily used for specifying functions that give insight into the lifecycle of each iteration. The possible extension points are `create`, `before`, `after` and `error`. If an extension point is not specified, it defaults to a no-op function.
 
-##### `extensions.create(value, key)`
+##### `options.create(value, key)`
 
 Called at the very beginning of each iteration with the `value` being iterated and the `key` from the array or object. If `create` returns a value (`storage`), it is passed to the `before`, `after` and `error` extension points.
 
@@ -172,15 +178,15 @@ If a value is not returned, an empty object is used as `storage` for each other 
 
 This is useful for tracking information across an iteration.
 
-##### `extensions.before(storage)`
+##### `options.before(storage)`
 
 Called immediately before each iteration with the `storage` value returned from the `create` extension point.
 
-##### `extensions.after(result, storage)`
+##### `options.after(result, storage)`
 
 Called immediately after each iteration with the `result` of the iteration and the `storage` value returned from the `create` extension point.
 
-##### `extensions.error(error, storage)`
+##### `options.error(error, storage)`
 
 Called immediately after a failed iteration with the `error` of the iteration and the `storage` value returned from the `create` extension point.
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -9,13 +9,13 @@ var defaultExts = {
   error: noop,
 };
 
-function defaultExtensions(extensions) {
-  extensions = extensions || {};
+function defaultExtensions(options) {
+  options = options || {};
   return {
-    create: extensions.create || defaultExts.create,
-    before: extensions.before || defaultExts.before,
-    after: extensions.after || defaultExts.after,
-    error: extensions.error || defaultExts.error,
+    create: options.create || defaultExts.create,
+    before: options.before || defaultExts.before,
+    after: options.after || defaultExts.after,
+    error: options.error || defaultExts.error,
   };
 }
 

--- a/lib/map.js
+++ b/lib/map.js
@@ -4,6 +4,12 @@ var once = require('once');
 
 var helpers = require('./helpers');
 
+function getMaxConcurrentIterations() {
+  var envVar = process.env['NAL_MAX_CONCURRENCY'];
+  var parsed = envVar && parseInt(envVar);
+  return parsed && parsed > 0 ? parsed : Number.MAX_SAFE_INTEGER;
+}
+
 function map(values, iterator, extensions, done) {
   // Allow for extensions to not be specified
   if (typeof extensions === 'function') {
@@ -32,12 +38,26 @@ function map(values, iterator, extensions, done) {
     return done(null, results);
   }
 
-  for (idx = 0; idx < length; idx++) {
-    var key = keys[idx];
-    next(key);
+  var maxConcurrent = getMaxConcurrentIterations();
+  var running = 0;
+  var sync = false;
+  kickoff();
+
+  function kickoff() {
+    if (sync) {
+      return;
+    }
+    sync = true;
+    while (running < maxConcurrent && idx < length) {
+      var key = keys[idx];
+      next(key);
+      idx++;
+    }
+    sync = false;
   }
 
   function next(key) {
+    running++;
     var value = values[key];
 
     var storage = exts.create(value, key) || {};
@@ -46,6 +66,7 @@ function map(values, iterator, extensions, done) {
     iterator(value, key, once(handler));
 
     function handler(err, result) {
+      running--;
       if (err) {
         exts.error(err, storage);
         return done(err, results);
@@ -55,6 +76,8 @@ function map(values, iterator, extensions, done) {
       results[key] = result;
       if (--count === 0) {
         done(err, results);
+      } else {
+        kickoff();
       }
     }
   }

--- a/lib/map.js
+++ b/lib/map.js
@@ -10,11 +10,11 @@ function getMaxConcurrentIterations() {
   return parsed && parsed > 0 ? parsed : Number.MAX_SAFE_INTEGER;
 }
 
-function map(values, iterator, extensions, done) {
-  // Allow for extensions to not be specified
-  if (typeof extensions === 'function') {
-    done = extensions;
-    extensions = {};
+function map(values, iterator, options, done) {
+  // Allow for options to not be specified
+  if (typeof options === 'function') {
+    done = options;
+    options = {};
   }
 
   // Handle no callback case
@@ -32,7 +32,7 @@ function map(values, iterator, extensions, done) {
   // Return the same type as passed in
   var results = helpers.initializeResults(values);
 
-  var exts = helpers.defaultExtensions(extensions);
+  var extensions = helpers.defaultExtensions(options);
 
   if (length === 0) {
     return done(null, results);
@@ -60,19 +60,19 @@ function map(values, iterator, extensions, done) {
     running++;
     var value = values[key];
 
-    var storage = exts.create(value, key) || {};
+    var storage = extensions.create(value, key) || {};
 
-    exts.before(storage);
+    extensions.before(storage);
     iterator(value, key, once(handler));
 
     function handler(err, result) {
       running--;
       if (err) {
-        exts.error(err, storage);
+        extensions.error(err, storage);
         return done(err, results);
       }
 
-      exts.after(result, storage);
+      extensions.after(result, storage);
       results[key] = result;
       if (--count === 0) {
         done(err, results);

--- a/lib/map.js
+++ b/lib/map.js
@@ -4,12 +4,6 @@ var once = require('once');
 
 var helpers = require('./helpers');
 
-function getMaxConcurrentIterations() {
-  var envVar = process.env['NAL_MAX_CONCURRENCY'];
-  var parsed = envVar && parseInt(envVar);
-  return parsed && parsed > 0 ? parsed : Number.MAX_SAFE_INTEGER;
-}
-
 function map(values, iterator, options, done) {
   // Allow for options to not be specified
   if (typeof options === 'function') {
@@ -38,7 +32,10 @@ function map(values, iterator, options, done) {
     return done(null, results);
   }
 
-  var maxConcurrent = getMaxConcurrentIterations();
+  var maxConcurrent = length;
+  if (options && options.concurrency) {
+    maxConcurrent = options.concurrency;
+  }
   var running = 0;
   var sync = false;
   kickoff();

--- a/lib/mapSeries.js
+++ b/lib/mapSeries.js
@@ -4,11 +4,11 @@ var once = require('once');
 
 var helpers = require('./helpers');
 
-function mapSeries(values, iterator, extensions, done) {
-  // Allow for extensions to not be specified
-  if (typeof extensions === 'function') {
-    done = extensions;
-    extensions = {};
+function mapSeries(values, iterator, options, done) {
+  // Allow for options to not be specified
+  if (typeof options === 'function') {
+    done = options;
+    options = {};
   }
 
   // Handle no callback case
@@ -25,7 +25,7 @@ function mapSeries(values, iterator, extensions, done) {
   // Return the same type as passed in
   var results = helpers.initializeResults(values);
 
-  var exts = helpers.defaultExtensions(extensions);
+  var extensions = helpers.defaultExtensions(options);
 
   if (length === 0) {
     return done(null, results);
@@ -37,18 +37,18 @@ function mapSeries(values, iterator, extensions, done) {
   function next(key) {
     var value = values[key];
 
-    var storage = exts.create(value, key) || {};
+    var storage = extensions.create(value, key) || {};
 
-    exts.before(storage);
+    extensions.before(storage);
     iterator(value, key, once(handler));
 
     function handler(err, result) {
       if (err) {
-        exts.error(err, storage);
+        extensions.error(err, storage);
         return done(err, results);
       }
 
-      exts.after(result, storage);
+      extensions.after(result, storage);
       results[key] = result;
 
       if (++idx >= length) {


### PR DESCRIPTION
Makes `map` aware of a `NAL_MAX_CONCURRENCY` environment variable which, when set to a positive integer, controls the maximum number of concurrent iterations which may be in-flight at once.

My usecase here is that I'd like to see a deterministic build log output order from a build I don't really control, which is run with either `gulp` or `just` (both of which use `undertaker`, which uses `bach` which uses this for its `parallel` mode). To do so, I'd like to set the maximum allowable concurrency to `1` concurrent operation at a time, this way the output log order isn't affected by the runtime of various operations. `lerna` and `rush` both allow doing this at the monorepo level, however there's no way to do it down at the individual task-runner level yet.

If this would be a welcome change to `now-and-later`, I can add some tests and documentation, or, if you think a "no concurrency" type feature would be better served in `undertaker` itself, I could look there, too (although at any layer above this you pretty much just get a yes/no, not a configurable maximum count, unless you amend `now-and-later`'s API to take an optional concurrency limit parameter).