### PR TITLE
map test: reports partial result after an error (series & parallel)

### DIFF
--- a/test/mapSeries.js
+++ b/test/mapSeries.js
@@ -264,4 +264,56 @@ describe('mapSeries', function () {
       done(err);
     });
   });
+
+  it('reports partial result after an error', function(done) {
+    var initial = {
+      test1: 'a',
+      test2: 'b',
+      test3: 'c',
+      test4: 'd',
+    };
+
+    var testedKeys = [];
+
+    var cbCount = 0;
+
+    function iterator(value, key, cb) {
+      testedKeys.push(key);
+
+      if (key === 'test1') {
+        cb(null, value);
+      } else if (key === 'test2') {
+        cb(null, key);
+      } else if (key === 'test3') {
+        // Report an error here
+        cb('Boom');
+      } else if (key === 'test4') {
+        // NOT expected to get here:
+        expect(false).toBe(true);
+        cb('crash');
+      } else {
+        // NOT expected to get here:
+        expect(false).toBe(true);
+        cb('crash');
+      }
+    }
+
+    nal.mapSeries(initial, iterator, function(err, res) {
+      expect(res).toEqual({
+        test1: 'a',
+        test2: 'test2',
+        test3: undefined,
+        test4: undefined,
+      });
+
+      expect(err).toBe('Boom');
+
+      expect(testedKeys).toEqual(['test1', 'test2', 'test3']);
+
+      expect(cbCount).toBe(0);
+      ++cbCount;
+
+      done();
+    });
+  });
 });


### PR DESCRIPTION
These test cases cover the effects of a `for` loop in `initializeResults()`, in `lib/helpers.js`.

Without this kind of a test case, it would be possible to remove the `for` loop (and an internal variable) without failing the test suite:

```diff
diff --git a/lib/helpers.js b/lib/helpers.js
index b0e913c..364c8c1 100644
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -20,17 +20,8 @@ function defaultExtensions(extensions) {
 }
 
 function initializeResults(values) {
-  var keys = Object.keys(values);
   var results = Array.isArray(values) ? [] : {};
 
-  var idx = 0;
-  var length = keys.length;
-
-  for (idx = 0; idx < length; idx++) {
-    var key = keys[idx];
-    results[key] = undefined;
-  }
-
   return results;
 }
 ```

This is a code mutation that I discovered through mutation testing using [Stryker Mutator](https://stryker-mutator.io/), which I will propose in an upcoming PR.

For the parallel `map` API call, the test case waits for both the callback and remaining iterator to finish. A little tricky, hopefully not too fragile:)