### PR TITLE
chore: Normalize repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ MIT
 [npm-image]: https://img.shields.io/npm/v/now-and-later.svg?style=flat-square
 
 [ci-url]: https://github.com/gulpjs/now-and-later/actions?query=workflow:dev
-[ci-image]: https://img.shields.io/github/workflow/status/gulpjs/now-and-later/dev?style=flat-square
+[ci-image]: https://img.shields.io/github/actions/workflow/status/gulpjs/now-and-later/dev.yml?branch=master&style=flat-square
 
 [coveralls-url]: https://coveralls.io/r/gulpjs/now-and-later
 [coveralls-image]: https://img.shields.io/coveralls/gulpjs/now-and-later/master.svg?style=flat-square


### PR DESCRIPTION
The URL of GitHub workflow badge was changed by `badges/shields`'s issue `#8671`.
This PR fixes the URL in `README.md`.